### PR TITLE
Add `export:csv` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,15 @@ Label management command.
 <!-- tocstop -->
 
 # Usage
-<!-- usage -->
 ```sh-session
-$ npm install -g @cli107/transverto
-$ ctv COMMAND
-running command...
-$ ctv (--version|-v)
-@cli107/transverto/1.0.0 win32-x64 node-v18.19.0
-$ ctv --help [COMMAND]
-USAGE
-  $ ctv COMMAND
-...
+$ npm install @cli107/transverto --save-dev
+$ ctv --help
 ```
-<!-- usagestop -->
 
 # Commands
 <!-- commands -->
 * [`ctv cache`](#ctv-cache)
+* [`ctv export:csv [LANGCODE]`](#ctv-exportcsv-langcode)
 * [`ctv help [COMMANDS]`](#ctv-help-commands)
 * [`ctv init`](#ctv-init)
 * [`ctv label [ADD] [DELETE] [GET] [REPLACE] [SYNC]`](#ctv-label-add-delete-get-replace-sync)
@@ -60,6 +52,44 @@ EXAMPLES
 ```
 
 _See code: [src/commands/cache.ts](https://github.com/4746/transverto/blob/v1.0.0/src/commands/cache.ts)_
+
+## `ctv export:csv [LANGCODE]`
+
+Export translations to file.
+
+```
+USAGE
+  $ ctv export:csv [LANGCODE] [-d <value>] [--eol cr|crlf|lf] [-i <value>] [-o <value>] [--withBOM]
+
+ARGUMENTS
+  LANGCODE  The language code. If not specified, all available translations are exported.
+
+FLAGS
+  -d, --delimiter=<value>   [default: ,] delimiter of columns.
+  -i, --include=<value>     include language code
+  -o, --outputFile=<value>  [default: dist/output.csv] Path to save the file
+      --eol=<option>        [default: lf]
+                            <options: cr|crlf|lf>
+      --withBOM             [default: false] with BOM character
+
+DESCRIPTION
+  Export translations to file.
+
+EXAMPLES
+  $ ctv export:csv
+
+  $ ctv export:csv en
+
+  $ ctv export:csv en --include=uk
+
+  $ ctv export:csv en --outputFile=dist/output.csv
+
+  $ ctv export:csv --delimiter=,
+
+  $ ctv export:csv --eol=lf
+```
+
+_See code: [src/commands/export/csv.ts](https://github.com/4746/transverto/blob/v1.0.0/src/commands/export/csv.ts)_
 
 ## `ctv help [COMMANDS]`
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "author": "Vadim",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bugs": "https://github.com/4746/transverto/issues",
   "homepage": "https://github.com/4746/transverto",
   "repository": "4746/transverto",
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^3.3.0",
+    "@json2csv/plainjs": "^7.0.4",
     "@oclif/core": "^3.16.0",
     "@oclif/plugin-help": "^6.0.10",
     "chalk": "^5.3.0",

--- a/src/commands/export/csv.ts
+++ b/src/commands/export/csv.ts
@@ -1,0 +1,136 @@
+import { Parser } from '@json2csv/plainjs';
+import {Args, Flags} from '@oclif/core'
+import chalk from "chalk";
+import fs from "node:fs";
+import path from "node:path";
+
+import {ITranslation} from "../../shared/entities/translate.js";
+import {LabelBaseCommand} from "../../shared/label-base.command.js";
+import {ELineSeparator, LINE_SEPARATOR_LOWER} from "../../shared/line-separator.js";
+import {UTIL} from "../../shared/util.js";
+
+/**
+ * node --loader ts-node/esm --no-warnings=ExperimentalWarning ./bin/dev export:csv
+ * node --loader ts-node/esm --no-warnings=ExperimentalWarning ./bin/dev export:csv en --include=uk
+ */
+export default class ExportCsv extends LabelBaseCommand<typeof ExportCsv> {
+  static args = {
+    langCode: Args.string({description: 'The language code. If not specified, all available translations are exported.', required: false}),
+  }
+
+  static description = 'Export translations to file.'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> en',
+    '<%= config.bin %> <%= command.id %> en --include=uk',
+    '<%= config.bin %> <%= command.id %> en --outputFile=dist/output.csv',
+    '<%= config.bin %> <%= command.id %> --delimiter=,',
+    '<%= config.bin %> <%= command.id %> --eol=lf',
+  ]
+
+  static flags = {
+    delimiter: Flags.string({char: 'd', default: ',', description: 'delimiter of columns.'}),
+    eol: Flags.string({
+      default: 'lf',
+      multiple: false,
+      options: LINE_SEPARATOR_LOWER,
+      requiredOrDefaulted: true,
+    }),
+    include: Flags.string({char: 'i', default: null, description: 'include language code', multiple: false, requiredOrDefaulted: true}),
+    outputFile: Flags.string({char: 'o', default: 'dist/output.csv', description: 'Path to save the file'}),
+    withBOM: Flags.boolean({description: '[default: false] with BOM character'}),
+  }
+
+  private csvFields = [
+    {
+      label: 'label',
+      value: 'label'
+    },
+  ];
+
+  private data: Record<string, Record<string, string>> = {};
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(ExportCsv)
+
+    await this.readCliConfig();
+
+    let langCode: string;
+    let includeLangCode: string;
+
+    if (args.langCode) {
+      langCode = await this.getLangCode(this.cliConfig.languages, args.langCode);
+
+      if (flags.include && this.cliConfig.languages.includes(flags.include)) {
+        includeLangCode = flags.include;
+      }
+    }
+
+    const mapTranslation =  await this.getTranslationLanguages();
+
+    if (args.langCode) {
+      this.langRows(mapTranslation[langCode]);
+
+      if (includeLangCode && includeLangCode !== langCode) {
+        this.langRows(mapTranslation[includeLangCode]);
+      }
+    } else {
+      for (langCode in mapTranslation) {
+        this.langRows(mapTranslation[langCode]);
+      }
+    }
+
+    const parser = new Parser({
+      delimiter : flags.delimiter,
+      eol: flags.eol ? ELineSeparator[flags.eol?.toUpperCase()] : ELineSeparator.LF,
+      fields: this.csvFields,
+      quote: `"`,
+      withBOM: flags.withBOM
+    });
+
+    const csv = parser.parse(Object.values(this.data));
+
+    await fs.promises.writeFile(path.resolve(flags.outputFile), csv, {encoding: 'utf8', flag: 'w'});
+
+    this.log(chalk.green(`File saved: ${path.resolve(flags.outputFile)}`));
+    this.log(chalk.cyan(`Done!`));
+  }
+
+  private langRows(mapLang: ITranslation) {
+    let label: string;
+    let value: string | string[];
+
+    for (label in mapLang.translateFlatten) {
+      value = mapLang.translateFlatten[label];
+
+      if (Array.isArray(value)) {
+        value = value.join('🏁');
+      } else if (!UTIL.isString(value)) {
+        value = '';
+      }
+
+      if (label in this.data) {
+        this.data[label][mapLang.code] = value;
+        this.data[label][`${mapLang.code}_new`] = '';
+      } else {
+        this.data[label] = {
+          [`${mapLang.code}_new`]: '',
+          label,
+          [mapLang.code]: value
+        }
+      }
+    }
+
+    this.csvFields.push(
+      {
+        label: mapLang.code,
+        value: mapLang.code,
+      },
+      {
+        label: `${mapLang.code}_new`,
+        value: `${mapLang.code}_new`,
+      }
+    );
+  }
+}

--- a/src/shared/line-separator.ts
+++ b/src/shared/line-separator.ts
@@ -1,0 +1,17 @@
+/**
+ * OS line ending
+ */
+export enum ELineSeparator {
+  /** Classic Mac OS */
+  CR = "\r",
+  /** Windows */
+  CRLF = "\r\n",
+  /** Unix */
+  LF = "\n",
+}
+
+export type TLineSeparatorLower = Lowercase<keyof typeof ELineSeparator>;
+/**
+ * Array of lowercase string values of the ELineSeparator enum.
+ */
+export const LINE_SEPARATOR_LOWER = Object.keys(ELineSeparator).map((v) => v.toLowerCase()) as TLineSeparatorLower[];

--- a/test/commands/export/csv.test.ts
+++ b/test/commands/export/csv.test.ts
@@ -1,0 +1,10 @@
+import {expect, test} from '@oclif/test'
+
+describe('export:csv', () => {
+  test
+  .stdout()
+  .command(['export:csv'])
+  .it('runs export:csv', ctx => {
+    expect(ctx.expectation).to.contain('export:csv')
+  })
+})


### PR DESCRIPTION
A new command, `export:csv`, has been added to export translations to a file.