### PR TITLE
Add label:get command and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Label management command.
 <!-- tocstop -->
 
 # Usage
-```sh-session
-$ npm install @cli107/transverto --save-dev
-$ ctv --help
+```shell
+npm install @cli107/transverto --save-dev
+```
+
+```shell
+ctv --help
 ```
 
 # Commands
@@ -27,6 +30,7 @@ $ ctv --help
 * [`ctv label [ADD] [DELETE] [GET] [REPLACE] [SYNC]`](#ctv-label-add-delete-get-replace-sync)
 * [`ctv label:add [LABEL]`](#ctv-labeladd-label)
 * [`ctv label:delete LABEL`](#ctv-labeldelete-label)
+* [`ctv label:get [LABEL]`](#ctv-labelget-label)
 * [`ctv label:replace LABEL`](#ctv-labelreplace-label)
 * [`ctv label:sync`](#ctv-labelsync)
 
@@ -137,7 +141,7 @@ _See code: [src/commands/init.ts](https://github.com/4746/transverto/blob/v1.1.0
 
 ## `ctv label [ADD] [DELETE] [GET] [REPLACE] [SYNC]`
 
-Represents a label management command.
+Label management command.
 
 ```
 USAGE
@@ -151,7 +155,7 @@ ARGUMENTS
   SYNC     A command to update labels synchronously.
 
 DESCRIPTION
-  Represents a label management command.
+  Label management command.
 ```
 
 _See code: [src/commands/label/index.ts](https://github.com/4746/transverto/blob/v1.1.0/src/commands/label/index.ts)_
@@ -212,6 +216,38 @@ EXAMPLES
 ```
 
 _See code: [src/commands/label/delete.ts](https://github.com/4746/transverto/blob/v1.1.0/src/commands/label/delete.ts)_
+
+## `ctv label:get [LABEL]`
+
+Display a list of translations for the specified label
+
+```
+USAGE
+  $ ctv label:get [LABEL] [--json] [-f <value>]
+
+ARGUMENTS
+  LABEL  A label key
+
+FLAGS
+  -f, --fromLangCode=<value>  The language code of source text.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Display a list of translations for the specified label
+
+EXAMPLES
+  $ ctv label:get
+
+  $ ctv label:get hello.world
+
+  $ ctv label:get hello.world -f="en"
+
+  $ ctv label:get hello.world -fen
+```
+
+_See code: [src/commands/label/get.ts](https://github.com/4746/transverto/blob/v1.1.0/src/commands/label/get.ts)_
 
 ## `ctv label:replace LABEL`
 
@@ -274,7 +310,7 @@ _See code: [src/commands/label/sync.ts](https://github.com/4746/transverto/blob/
   "basePath": "dist/i18n",
   "basePathEnum": "dist/i18n/language.ts",
   "bing": {
-    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0"
+    "userAgent": "..."
   },
   "engine": "bing",
   "engineUseCache": false,
@@ -282,7 +318,8 @@ _See code: [src/commands/label/sync.ts](https://github.com/4746/transverto/blob/
   "languages": [
     "en"
   ],
-  "nameEnum": "LanguageLabel"
+  "nameEnum": "LanguageLabel",
+  "userAgent": "..."
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cli107/transverto",
-  "description": "CLI transverto label management",
+  "description": "Generate automatically translations for your i18n json translate files",
   "keywords": [
     "transverto",
     "translate",
@@ -12,7 +12,7 @@
   ],
   "author": "Vadim",
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "bugs": "https://github.com/4746/transverto/issues",
   "homepage": "https://github.com/4746/transverto",
   "repository": "4746/transverto",
@@ -27,7 +27,7 @@
     "prepack": "npm run build && oclif manifest && oclif readme",
     "prepare": "npm run build",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif readme && git add README.md",
+    "version": "oclif readme",
     "win:delete:node_modules": "rd /s /q \"node_modules\"",
     "npm:cache:clean": "npm cache clean --force",
     "generate-config:bing": "node scripts/bing.generate-config.mjs",

--- a/src/commands/label/get.ts
+++ b/src/commands/label/get.ts
@@ -1,0 +1,119 @@
+import {Args, Flags, ux} from '@oclif/core'
+import chalk from "chalk";
+
+import {LabelBaseCommand} from "../../shared/label-base.command.js";
+
+/**
+ * node --loader ts-node/esm --no-warnings=ExperimentalWarning ./bin/dev label:get
+ * node --loader ts-node/esm --no-warnings=ExperimentalWarning ./bin/dev label:get hello.world
+ * node --loader ts-node/esm --no-warnings=ExperimentalWarning ./bin/dev label:get hello.world -f="en"
+ */
+export default class LabelGet extends LabelBaseCommand<typeof LabelGet> {
+  static args = {
+    label: Args.string({default: null,  description: 'A label key', requiredOrDefaulted: true}),
+  }
+
+  static description = 'Display a list of translations for the specified label'
+
+  static enableJsonFlag = true;
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> hello.world',
+    '<%= config.bin %> <%= command.id %> hello.world -f="en"',
+    '<%= config.bin %> <%= command.id %> hello.world -fen',
+  ]
+
+  static flags = {
+    fromLangCode: Flags.string({char: 'f', description: 'The language code of source text.'}),
+  }
+
+  public async run(): Promise<NonNullable<object> | void> {
+    const {args, flags} = await this.parse(LabelGet);
+
+    await this.readCliConfig();
+
+    const mapLangs =  await this.getTranslationLanguages();
+
+    const rows = [];
+
+    let code: string;
+    if (flags.fromLangCode) {
+      code = await this.getLangCode(this.cliConfig.languages, flags.fromLangCode, this.cliConfig.langCodeDefault);
+
+      const data = this.findLabels(args.label, mapLangs[code].translateFlatten).map((row) => {
+        return {code, ...row};
+      });
+
+      rows.push(...data)
+    } else {
+      for (code in mapLangs) {
+        const data = this.findLabels(args.label, mapLangs[code].translateFlatten).map((row) => {
+          return {code, ...row};
+        });
+
+        rows.push(...data)
+      }
+    }
+
+    if (this.jsonEnabled()) {
+      return rows
+    }
+
+    ux.table(rows.map((v, k) => ({
+      ...v, id: (k + 1).toString(),
+    })), {
+      id: {
+        header: '#',
+        minWidth: 7,
+      },
+      // eslint-disable-next-line
+      code: {
+        get: (row) => {
+          return chalk.yellow(row.code);
+        },
+        header: 'Code',
+        minWidth: 10,
+      },
+      label: {
+        get: (row) => {
+          return chalk.green(row.label);
+        },
+        header: 'Label',
+        minWidth: 20,
+      },
+      trans: {
+        get: (row) => {
+          return chalk.cyan(row.trans);
+        },
+        header: 'Translate',
+        minWidth: 20,
+      }
+    }, {
+      'no-truncate': true
+    })
+  }
+
+  private findLabels(label: string, translateFlatten:  Record<string, string | string[]>) {
+    const rows = [];
+
+    if (label in translateFlatten) {
+      rows.push({
+        label,
+        trans: translateFlatten[label]
+      });
+    }
+
+    let labelKey: string;
+    for (labelKey in translateFlatten) {
+      if (labelKey.startsWith(`${label}.`)) {
+        rows.push({
+          label: labelKey,
+          trans: translateFlatten[labelKey]
+        });
+      }
+    }
+
+    return rows;
+  }
+}

--- a/src/commands/label/index.ts
+++ b/src/commands/label/index.ts
@@ -9,7 +9,7 @@ export default class Label extends Command {
     sync: Args.string({description: 'A command to update labels synchronously.', required: false}),
   }
 
-  static description = 'Represents a label management command.'
+  static description = 'Label management command.'
 
   async run(): Promise<void> {
     // const {args} = await this.parse(Label)

--- a/test/commands/label/get.test.ts
+++ b/test/commands/label/get.test.ts
@@ -1,0 +1,10 @@
+import {expect, test} from '@oclif/test'
+
+describe('label:get', () => {
+  test
+  .stdout()
+  .command(['label:get', 'hello.world'])
+  .it('runs label:get hello.world', ctx => {
+    expect(ctx.expectation).to.contain('label:get hello.world')
+  })
+})


### PR DESCRIPTION
Added a new command, "label:get", in the application which is responsible for displaying a list of translations for a specific label. Additionally, unit tests are created to ensure the proper functioning of this new command. Also made minor changes to the README file to reflect these changes and updated the application's description and version in package.json.