### PR TITLE
Update version number and 'got' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "author": "Vadim",
   "license": "MIT",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "bugs": "https://github.com/4746/transverto/issues",
   "homepage": "https://github.com/4746/transverto",
   "repository": "4746/transverto",
@@ -43,7 +43,7 @@
     "@oclif/plugin-help": "^6.0.10",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
-    "got": "^14 || ^13",
+    "got": "14.0.0",
     "listr2": "^8.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The 'got' dependency in package.json has been fixed to version 14.0.0, no longer allowing for the dual version (14 or 13) flexibility. This offers improved stability in different environments. The version number has also been updated from 1.2.1 to 1.2.2.